### PR TITLE
level fixes

### DIFF
--- a/lib/Log/Declare.pm
+++ b/lib/Log/Declare.pm
@@ -1,13 +1,27 @@
 package Log::Declare;
 # ABSTRACT: A high performance Perl logging module.
 
+use 5.10.0; # for //
 use strict;
+use warnings;
+
 use Devel::Declare::Lexer;
 use Devel::Declare::Lexer::Token::Raw;
 use POSIX qw(strftime);
 use Data::Dumper; # for d: statements
 
 our $VERSION = '0.06';
+
+my %LEVEL = (
+    TRACE   => 1,
+    DEBUG   => 2,
+    INFO    => 3,
+    WARN    => 4,
+    ERROR   => 5,
+    AUDIT   => 6,
+    NONE    => 7,
+    DISABLE => 7,
+);
 
 my $startup_level = uc ($ENV{'LOG_DECLARE_STARTUP_LEVEL'} || 'ERROR');
 my $log_statement = "Log::Declare->log('%s', [%s], %s)%s";
@@ -18,7 +32,6 @@ unless($ENV{LOG_DECLARE_NO_STARTUP_NOTICE}) {
 
 # These provide return values for injected keywords - a 0 here means the level
 # is completely disabled and won't be received by the log writer
-our @level_priority = ( 'audit', 'info', 'error', 'warn', 'debug', 'trace' );
 our %levels = (
     audit => sub { 1 },
     info  => sub { 1 },
@@ -198,7 +211,7 @@ sub startup_level {
     my ($self, $level) = @_;
 
     return $startup_level unless $level;
-    $startup_level = $level;
+    $startup_level = uc $level;
     return $startup_level;
 }
 
@@ -217,25 +230,21 @@ sub log_statement {
 sub log {
     my ($self, $level, $categories, $message) = @_;
 
+    $level = uc $level;
+
+    # if the log level is invalid/mistyped, default to all levels (-1)
+    return unless $LEVEL{$level} >= ($LEVEL{$startup_level} // -1);
+
     if($categories) {
         $categories = scalar @$categories > 0 ? (join ', ', @$categories) : '';
         $categories = " [$categories]";
     }
-
-    my $allowed = 0;
-    for my $lvl (@Log::Declare::level_priority) {
-        $allowed = 1 if $lvl eq $level;
-        last if uc $lvl eq uc $startup_level;
-    }
-
-    return if !$allowed;
 
     my $ts = strftime $ENV{'LOG_DECLARE_DATE_FORMAT'} // "%a %b %e %H:%M:%S %Y",
                       ($ENV{'LOG_DECLARE_USE_LOCALTIME'} ? localtime : gmtime);
 
     $message .= "\n" if substr($message,-1) ne "\n";
 
-    $level = uc $level;
     return CORE::print STDERR "$$ [$ts] [$level]$categories $message";
 }
 
@@ -280,7 +289,7 @@ sub do_import {
     my %t = map { $_ => 1 } @tags;
     return if $t{':nosyntax'};
 
-    # Inject each of the keywords into callers namespace
+    # Inject each of the keywords into caller's namespace
     Devel::Declare::Lexer::import_for($caller, { 'error' => sub { goto $Log::Declare::levels{'error' } } } ) if !$t{':noerror'};
     Devel::Declare::Lexer::import_for($caller, { 'trace' => sub { goto $Log::Declare::levels{'trace' } } } ) if !$t{':notrace'};
     Devel::Declare::Lexer::import_for($caller, { 'debug' => sub { goto $Log::Declare::levels{'debug' } } } ) if !$t{':nodebug'};
@@ -346,7 +355,7 @@ which means if 'info' returns 0, nothing else gets evaluated.
 
 =head1 NAMESPACES
 
-If you're using a namespace aware logger, Log::Declare can use your loggers
+If you're using a namespace-aware logger, Log::Declare can use your logger's
 namespacing to determine log levels. For example:
 
     $Log::Declare::levels{'debug'} = sub {

--- a/t/levels.pl
+++ b/t/levels.pl
@@ -1,0 +1,16 @@
+#!/usr/bin/env perl
+
+use strict;
+
+use Log::Declare;
+
+print STDERR 'START', $/;
+
+trace 'trace';
+debug 'debug';
+info  'info';
+warn  'warn';
+error 'error';
+audit 'audit';
+
+print STDERR 'END', $/;

--- a/t/levels.t
+++ b/t/levels.t
@@ -1,0 +1,68 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Data::Dumper;
+use FindBin qw($Bin);
+use Test::More tests => 60;
+
+$Data::Dumper::Indent = 0;
+$Data::Dumper::Terse  = 1;
+
+$ENV{LOG_DECLARE_NO_STARTUP_NOTICE} = 1;
+
+sub is_enabled {
+    my ($level, $expected_levels) = @_;
+
+    local $ENV{LOG_DECLARE_STARTUP_LEVEL} = $level;
+    local $Test::Builder::Level = $Test::Builder::Level + 1;
+
+    # my $stderr = capture_stderr { system { $^X } ($^X, "$Bin/levels.pl") };
+    my $stderr = qx{ $^X "$Bin/levels.pl" 2>&1 }; # XXX use Capture::Tiny
+    my @stderr = split $/, $stderr;
+
+    is shift(@stderr), 'START';
+    is pop(@stderr),   'END';
+
+    # all of the levels >= the current level (may be empty)
+    # e.g. for INFO: [ 'info', 'warn', 'error' ]
+    my $enabled_levels = [ map { /(\w+)$/ } @stderr ];
+
+    # level errors are easier to diagnose with strings than with arrayrefs/is_deeply
+    is (
+        join(', ', @$enabled_levels),
+        join(', ', @$expected_levels),
+        sprintf('enabled log levels for %s: %s', Dumper($level), Dumper($expected_levels))
+    );
+}
+
+is_enabled undef, [ qw(error audit) ];
+is_enabled '', [ qw(error audit) ];
+
+is_enabled 'invalid', [ qw(trace debug info warn error audit) ];
+is_enabled 'INVALID', [ qw(trace debug info warn error audit) ];
+
+is_enabled 'trace', [ qw(trace debug info warn error audit) ];
+is_enabled 'TRACE', [ qw(trace debug info warn error audit) ];
+
+is_enabled 'debug', [ qw(debug info warn error audit) ];
+is_enabled 'DEBUG', [ qw(debug info warn error audit) ];
+
+is_enabled 'info', [ qw(info warn error audit) ];
+is_enabled 'INFO', [ qw(info warn error audit) ];
+
+is_enabled 'warn', [ qw(warn error audit) ];
+is_enabled 'WARN', [ qw(warn error audit) ];
+
+is_enabled 'error', [ qw(error audit) ];
+is_enabled 'ERROR', [ qw(error audit) ];
+
+is_enabled 'audit', [ qw(audit) ];
+is_enabled 'AUDIT', [ qw(audit) ];
+
+is_enabled 'none', [];
+is_enabled 'NONE', [];
+
+is_enabled 'disable', [];
+is_enabled 'DISABLE', [];


### PR DESCRIPTION
fix incorrect handling of INFO*
allow logging to be disabled via NONE or DISABLED
more efficient enabled/disabled checking
test case-insensitivity
fix doc typos + test warning

\* INFO is borked (it's higher than ERROR) e.g. setting LOG_DECLARE_STARTUP_LEVEL=INFO disables WARN and ERROR and setting LOG_DECLARE_STARTUP_LEVEL=WARN enables INFO. This makes it a pretty much impossible to filter out logspam.
