### PR TITLE
level fixes

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,13 @@
 Revision history for Perl module Log::Declare
 
+0.10 2014-07-31
+
+ - fix issue with trace, debug &c. always returning true/not short-circuiting
+ - fix INFO priority
+ - allow logging to be disabled via OFF or DISABLED
+ - more efficient level checking
+ - flag MojoX::Log::Declare compatibility gotcha
+
 0.06 2014-06-21
  - introduce audit log level
 

--- a/lib/Log/Declare.pm
+++ b/lib/Log/Declare.pm
@@ -10,7 +10,7 @@ use Devel::Declare::Lexer::Token::Raw;
 use POSIX qw(strftime);
 use Data::Dumper; # for d: statements
 
-our $VERSION = '0.06';
+our $VERSION = '0.10';
 
 my %LEVEL = (
     ALL     => -1,

--- a/t/enabled.t
+++ b/t/enabled.t
@@ -1,0 +1,53 @@
+#!/usr/bin/env perl
+
+# the whole premise of Log::Declare is that a) arguments should not be evaluated and
+# b) Log::Declare->log(...) should not be called unless c) the log level is enabled e.g.:
+#
+#     info "foo: %s", Dumper($foo);
+#
+# is translated to:
+#
+#     Log::Declare->log('info', ['GENERAL'], sprintf('foo: %s', Dumper($foo))) if info();
+#
+# confirm that the log-level functions behave as expected i.e. return true if the
+# log level is enabled, and false otherwise
+
+use strict;
+use warnings;
+
+use Test::More tests => 72;
+
+# keep our own record of the levels and their expected relations. this allows the
+# test to be run on older versions of the module, and prevents tight (i.e. redundant)
+# coupling between the testing and tested fixtures
+my @LEVELS = qw(trace debug info warn error audit);
+my %LEVEL = map { $LEVELS[$_] => $_ + 1 } (0 .. $#LEVELS);
+
+$LEVEL{off} = $LEVEL{disable} = @LEVELS + 1;
+$LEVEL{all} = $LEVEL{any} = $LEVEL{invalid} = $LEVEL{mistyped} = -1;
+
+{
+    package Log::Declare::t;
+
+    use blib;
+    use Log::Declare;
+
+    sub get_enabled {
+        Log::Declare->startup_level(shift);
+        return { map { $_ => __PACKAGE__->can($_)->() || 0 } @LEVELS };
+    }
+}
+
+for my $level (keys %LEVEL) {
+    my $enabled = Log::Declare::t::get_enabled($level);
+
+    for my $key (keys %$enabled) {
+        my $value = $enabled->{$key};
+
+        if ($LEVEL{$key} >= $LEVEL{$level}) { # message level >= (global) log level/threshold: enabled
+            ok($value, "threshold: $level, message: $key: enabled: 1");
+        } else { # message level < (global) log level/threshold: disabled
+            ok(!$value, "threshold: $level, message: $key: enabled: 0");
+        }
+    }
+}

--- a/t/levels.pl
+++ b/t/levels.pl
@@ -1,0 +1,16 @@
+#!/usr/bin/env perl
+
+use strict;
+
+use Log::Declare;
+
+print STDERR 'START', $/;
+
+trace 'trace';
+debug 'debug';
+info  'info';
+warn  'warn';
+error 'error';
+audit 'audit';
+
+print STDERR 'END', $/;

--- a/t/levels.t
+++ b/t/levels.t
@@ -1,0 +1,68 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Data::Dumper;
+use FindBin qw($Bin);
+use Test::More tests => 60;
+
+$Data::Dumper::Indent = 0;
+$Data::Dumper::Terse  = 1;
+
+$ENV{LOG_DECLARE_NO_STARTUP_NOTICE} = 1;
+
+sub is_enabled {
+    my ($level, $expected_levels) = @_;
+
+    local $ENV{LOG_DECLARE_STARTUP_LEVEL} = $level;
+    local $Test::Builder::Level = $Test::Builder::Level + 1;
+
+    # my $stderr = capture_stderr { system { $^X } ($^X, "$Bin/levels.pl") };
+    my $stderr = qx{ $^X -Mblib "$Bin/levels.pl" 2>&1 }; # XXX use Capture::Tiny
+    my @stderr = split $/, $stderr;
+
+    is shift(@stderr), 'START';
+    is pop(@stderr),   'END';
+
+    # all of the levels >= the current level (may be empty)
+    # e.g. for INFO: [ 'info', 'warn', 'error', 'audit' ]
+    my $enabled_levels = [ map { /(\w+)$/ } @stderr ];
+
+    # level errors are easier to diagnose with strings than with arrayrefs/is_deeply
+    is (
+        join(', ', @$enabled_levels),
+        join(', ', @$expected_levels),
+        sprintf('enabled log levels for %s: %s', Dumper($level), Dumper($expected_levels))
+    );
+}
+
+is_enabled undef, [ qw(error audit) ];
+is_enabled '', [ qw(error audit) ];
+
+is_enabled invalid => [ qw(trace debug info warn error audit) ];
+is_enabled INVALID => [ qw(trace debug info warn error audit) ];
+
+is_enabled trace => [ qw(trace debug info warn error audit) ];
+is_enabled TRACE => [ qw(trace debug info warn error audit) ];
+
+is_enabled debug => [ qw(debug info warn error audit) ];
+is_enabled DEBUG => [ qw(debug info warn error audit) ];
+
+is_enabled info => [ qw(info warn error audit) ];
+is_enabled INFO => [ qw(info warn error audit) ];
+
+is_enabled warn => [ qw(warn error audit) ];
+is_enabled WARN => [ qw(warn error audit) ];
+
+is_enabled error => [ qw(error audit) ];
+is_enabled ERROR => [ qw(error audit) ];
+
+is_enabled audit => [ qw(audit) ];
+is_enabled AUDIT => [ qw(audit) ];
+
+is_enabled off => [];
+is_enabled OFF => [];
+
+is_enabled disable => [];
+is_enabled DISABLE => [];

--- a/t/log_declare.t
+++ b/t/log_declare.t
@@ -231,8 +231,8 @@ sub test_method_namespace {
     subtest "Test namespace awareness" => sub {
         plan tests => 3;
 
-        # Localise log-level changes
-        local *trace;
+        # limit %levels changes to this scope
+        local %Log::Declare::levels;
 
         # Capture STDERR and reopen it attached to a variable
         open SAVEERR, ">&STDERR";
@@ -242,16 +242,15 @@ sub test_method_namespace {
 
         Log::Declare->startup_level('TRACE');
 
-        *trace = sub {
+        $Log::Declare::levels{'trace'} = sub {
             return 0;
         };
-
         trace "message";
         chomp $stderr;
         like($stderr, qr/^$/, 'Test disabled log level');
         $stderr = '';
 
-        *trace = sub {
+        $Log::Declare::levels{'trace'} = sub {
             return 1;
         };
         trace "message";
@@ -259,7 +258,7 @@ sub test_method_namespace {
         like($stderr, qr/\[\w+\s+\w+\s+\d+\s\d+:\d+:\d+\s\d+\]\s\[TRACE\]\s\[GENERAL\]\smessage/, 'Test enabled log level');
         $stderr = '';
 
-        *trace = sub {
+        $Log::Declare::levels{'trace'} = sub {
             my @caller = caller;
             is($caller[0], 'Log::Declare::t', 'Caller is correct');
             return 0;

--- a/t/log_declare.t
+++ b/t/log_declare.t
@@ -37,13 +37,13 @@ BEGIN {
 
     $Log::Declare::t::init_stderr = $stderr;
 }
-    
+
 test_method_import();
 test_method_parser();
 test_method_namespace();
 test_method_auto();
 test_method_capture();
-    
+
 done_testing();
 
 # =============================================================================
@@ -209,10 +209,10 @@ sub test_method_parser {
         $stderr = '';
 
         # TODO this used to work with manual parsing, Devel::Declare::Lexer seems to struggle
-        info 
-            "message %s %s", 
-            $a, 
-            $b 
+        info
+            "message %s %s",
+            $a,
+            $b
             [cat1, cat2];
         chomp $stderr;
         like($stderr, qr/\[\w+\s+\w+\s+\d+\s\d+:\d+:\d+\s\d+\]\s\[INFO\]\s\[CAT1,\sCAT2\]\smessage a b/, 'Test multiple categories with multiple argument sprintf with variables and newlines');
@@ -231,6 +231,9 @@ sub test_method_namespace {
     subtest "Test namespace awareness" => sub {
         plan tests => 3;
 
+        # Localise log-level changes
+        local *trace;
+
         # Capture STDERR and reopen it attached to a variable
         open SAVEERR, ">&STDERR";
         close STDERR;
@@ -239,15 +242,16 @@ sub test_method_namespace {
 
         Log::Declare->startup_level('TRACE');
 
-        $Log::Declare::levels{'trace'} = sub {
+        *trace = sub {
             return 0;
         };
+
         trace "message";
         chomp $stderr;
         like($stderr, qr/^$/, 'Test disabled log level');
         $stderr = '';
 
-        $Log::Declare::levels{'trace'} = sub {
+        *trace = sub {
             return 1;
         };
         trace "message";
@@ -255,16 +259,13 @@ sub test_method_namespace {
         like($stderr, qr/\[\w+\s+\w+\s+\d+\s\d+:\d+:\d+\s\d+\]\s\[TRACE\]\s\[GENERAL\]\smessage/, 'Test enabled log level');
         $stderr = '';
 
-        $Log::Declare::levels{'trace'} = sub {
+        *trace = sub {
             my @caller = caller;
             is($caller[0], 'Log::Declare::t', 'Caller is correct');
             return 0;
         };
         trace "message";
 
-        # Restore log level
-        $Log::Declare::levels{'trace'} = sub { 1 };
-        
         # Close the new STDERR and point it back to the original
         close STDERR;
         open STDERR, ">&SAVEERR";
@@ -297,7 +298,7 @@ sub test_method_auto {
         chomp $stderr;
         like($stderr, qr/\[\w+\s+\w+\s+\d+\s\d+:\d+:\d+\s\d+\]\s\[TRACE\]\s\[GENERAL\]\smessage\sHASH/, 'Test auto ref');
         $stderr = '';
-        
+
         # Close the new STDERR and point it back to the original
         close STDERR;
         open STDERR, ">&SAVEERR";
@@ -350,7 +351,7 @@ sub test_method_capture {
         chomp $stderr;
         like($stderr, qr/\[\w+\s+\w+\s+\d+\s\d+:\d+:\d+\s\d+\]\s\[DEBUG\]\s\[Test::Logger\]\sIntercepted/, 'Test intercepted capture');
         $stderr = '';
-        
+
         # Close the new STDERR and point it back to the original
         close STDERR;
         open STDERR, ">&SAVEERR";


### PR DESCRIPTION
```
- fix incorrect handling of INFO
- allow logging to be disabled via OFF or DISABLED
- more efficient level checking
- flag MojoX::Log::Declare compatibility gotcha
- test case-insensitivity
- fix doc typos
```

This is virtually the same as the [previous pull request](https://github.com/companieshouse/Log-Declare/pull/3), but includes a fix for the Hypnotoad issue, which was actually a [MojoX::Log::Declare compatibility](https://github.com/companieshouse/MojoX-Log-Declare/blob/d76f15344628bc830a4d4f0f75d0c84c787a9cb6/lib/MojoX/Log/Declare.pm#L16) issue (fixed by restoring `@Log::Declare::level_priority`).
